### PR TITLE
Also find a reference on 'Id' instead of only 'ID'

### DIFF
--- a/signedxml.go
+++ b/signedxml.go
@@ -200,18 +200,26 @@ func getReferencedXML(reference *etree.Element, inputDoc *etree.Document) (outpu
 	if uri == "" {
 		outputDoc = inputDoc
 	} else {
-		path := fmt.Sprintf(".//[@ID='%s']", uri)
+		path := fmt.Sprintf(".//[@Id='%s']", uri)
 		e := inputDoc.FindElement(path)
 		if e != nil {
 			outputDoc = etree.NewDocument()
 			outputDoc.SetRoot(e.Copy())
 		} else {
-			// SAML v1.1 Assertions use AssertionID
-			path := fmt.Sprintf(".//[@AssertionID='%s']", uri)
+			// Also find ID instead of Id
+			path := fmt.Sprintf(".//[@ID='%s']", uri)
 			e := inputDoc.FindElement(path)
 			if e != nil {
 				outputDoc = etree.NewDocument()
 				outputDoc.SetRoot(e.Copy())
+			} else {
+				// SAML v1.1 Assertions use AssertionID
+				path := fmt.Sprintf(".//[@AssertionID='%s']", uri)
+				e := inputDoc.FindElement(path)
+				if e != nil {
+					outputDoc = etree.NewDocument()
+					outputDoc.SetRoot(e.Copy())
+				}
 			}
 		}
 	}


### PR DESCRIPTION
References are only found on the 'ID' attribute, but my references where on 'Id'.
Not sure if you still maintain this library, but maybe this pull request will help other users with the same problem. Thanks for the great library!