### PR TITLE
Fix nested namespace overriding problem

### DIFF
--- a/exclusivecanonicalization.go
+++ b/exclusivecanonicalization.go
@@ -149,6 +149,9 @@ func (e ExclusiveCanonicalization) processRecursive(node *etree.Element,
 		e.renderAttributes(node, prefixesInScope, defaultNS)
 
 	for _, child := range node.Child {
+		oldNamespaces := e.namespaces
+		e.namespaces = copyNamespace(oldNamespaces)
+		
 		switch child := child.(type) {
 		case *etree.Comment:
 			if !e.WithComments {
@@ -157,6 +160,8 @@ func (e ExclusiveCanonicalization) processRecursive(node *etree.Element,
 		case *etree.Element:
 			e.processRecursive(child, newPrefixesInScope, newDefaultNS)
 		}
+		
+		e.namespaces = oldNamespaces
 	}
 }
 

--- a/exclusivecanonicalization.go
+++ b/exclusivecanonicalization.go
@@ -305,3 +305,12 @@ func isWhitespace(s string) bool {
 	}
 	return true
 }
+
+func copyNamespace(namespaces map[string]string) map[string]string {
+	newVersion := map[string]string{}
+	for index, element := range namespaces {
+		newVersion[index] = element
+	}
+	return newVersion
+}
+


### PR DESCRIPTION
e.namespaces was overridden by its child. So each time init a new namespace map and use it.