### PR TITLE
Fix broken signatures when attributes are prefixed with `xml`

### DIFF
--- a/exclusivecanonicalization.go
+++ b/exclusivecanonicalization.go
@@ -209,7 +209,10 @@ func (e ExclusiveCanonicalization) renderAttributes(node *etree.Element,
 			attr.Space != "xmlns" &&
 			!contains(prefixesInScope, attr.Space) {
 
-			nsListToRender["xmlns:"+attr.Space] = e.namespaces[attr.Space]
+			if attr.Space != "xml"{
+				nsListToRender["xmlns:"+attr.Space] = e.namespaces[attr.Space]
+			}
+
 			prefixesInScope = append(prefixesInScope, attr.Space)
 		}
 


### PR DESCRIPTION
I noticed that the document signature is invalid if the document contains `xml:lang` attributes, i.e:

```
<mdui:DisplayName xml:lang="en">Example</mdui:DisplayName>
```

After some debugging I found the offending line in https://github.com/ma314smith/signedxml/blob/5961fe7b44fd9545cd43abb39777f5f6fab40705/exclusivecanonicalization.go#L212.
This line causes the attribute `xmlns:xml` (without value) to be created in the in-memory version of the document at the time the digest is calculated.

This PR just wraps it in a simple `if` statement, though I'm not sure that line should be there at all...